### PR TITLE
feat: add loan scenarios and calculators

### DIFF
--- a/apps/backend/db/migrations/0001_create_loan_scenarios.sql
+++ b/apps/backend/db/migrations/0001_create_loan_scenarios.sql
@@ -1,0 +1,20 @@
+-- Migration to create clients and loan_scenarios tables
+
+CREATE TABLE IF NOT EXISTS clients (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS loan_scenarios (
+    id SERIAL PRIMARY KEY,
+    client_id INTEGER NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+    scenario_name VARCHAR(255) NOT NULL,
+    principal NUMERIC(15,2) NOT NULL,
+    annual_rate NUMERIC(5,2) NOT NULL,
+    term_months INTEGER NOT NULL,
+    buydown_rate NUMERIC(5,2) DEFAULT 0,
+    buydown_months INTEGER DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/apps/backend/src/services/loanCalc.ts
+++ b/apps/backend/src/services/loanCalc.ts
@@ -1,0 +1,81 @@
+export interface AmortizationPayment {
+  month: number;
+  payment: number;
+  principal: number;
+  interest: number;
+  balance: number;
+}
+
+/**
+ * Calculate standard amortization schedule for a loan.
+ * @param principal loan amount
+ * @param annualRate annual interest rate as percentage (e.g. 5 for 5%)
+ * @param termMonths number of months for the loan
+ */
+export function calculateAmortization(
+  principal: number,
+  annualRate: number,
+  termMonths: number
+): AmortizationPayment[] {
+  const monthlyRate = annualRate / 12 / 100;
+  const payment =
+    (principal * monthlyRate) /
+    (1 - Math.pow(1 + monthlyRate, -termMonths));
+
+  const schedule: AmortizationPayment[] = [];
+  let balance = principal;
+
+  for (let month = 1; month <= termMonths; month++) {
+    const interest = balance * monthlyRate;
+    const principalPaid = payment - interest;
+    balance = Math.max(0, balance - principalPaid);
+    schedule.push({
+      month,
+      payment,
+      principal: principalPaid,
+      interest,
+      balance,
+    });
+  }
+  return schedule;
+}
+
+/**
+ * Calculate payments for a simple rate buydown where the interest rate is
+ * reduced by `buydownRate` for the first `buydownMonths` payments.
+ */
+export function calculateBuydown(
+  principal: number,
+  annualRate: number,
+  termMonths: number,
+  buydownRate: number,
+  buydownMonths: number
+): AmortizationPayment[] {
+  const baseRate = annualRate / 12 / 100;
+  const buydownMonthlyRate = (annualRate - buydownRate) / 12 / 100;
+
+  const basePayment =
+    (principal * baseRate) / (1 - Math.pow(1 + baseRate, -termMonths));
+  const buydownPayment =
+    (principal * buydownMonthlyRate) /
+    (1 - Math.pow(1 + buydownMonthlyRate, -termMonths));
+
+  const schedule: AmortizationPayment[] = [];
+  let balance = principal;
+
+  for (let month = 1; month <= termMonths; month++) {
+    const rate = month <= buydownMonths ? buydownMonthlyRate : baseRate;
+    const payment = month <= buydownMonths ? buydownPayment : basePayment;
+    const interest = balance * rate;
+    const principalPaid = payment - interest;
+    balance = Math.max(0, balance - principalPaid);
+    schedule.push({
+      month,
+      payment,
+      principal: principalPaid,
+      interest,
+      balance,
+    });
+  }
+  return schedule;
+}

--- a/apps/frontend/src/features/scenarios/ScenarioPlanner.tsx
+++ b/apps/frontend/src/features/scenarios/ScenarioPlanner.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+
+type ScenarioInput = {
+  principal: number;
+  annualRate: number;
+  termMonths: number;
+  buydownRate: number;
+  buydownMonths: number;
+};
+
+export default function ScenarioPlanner() {
+  const [input, setInput] = useState<ScenarioInput>({
+    principal: 200000,
+    annualRate: 5,
+    termMonths: 360,
+    buydownRate: 1,
+    buydownMonths: 12,
+  });
+  const [schedule, setSchedule] = useState<any[]>([]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setInput((prev) => ({ ...prev, [name]: Number(value) }));
+  };
+
+  const calculate = async () => {
+    try {
+      const res = await fetch("/api/loan/calc", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      const data = await res.json();
+      setSchedule(data);
+    } catch (e) {
+      console.error("Calculation failed", e);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Scenario Planner</h2>
+      <div>
+        <label>
+          Principal
+          <input
+            name="principal"
+            type="number"
+            value={input.principal}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Rate (%)
+          <input
+            name="annualRate"
+            type="number"
+            value={input.annualRate}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Term (months)
+          <input
+            name="termMonths"
+            type="number"
+            value={input.termMonths}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Buydown Rate (%)
+          <input
+            name="buydownRate"
+            type="number"
+            value={input.buydownRate}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Buydown Months
+          <input
+            name="buydownMonths"
+            type="number"
+            value={input.buydownMonths}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <button onClick={calculate}>Calculate</button>
+      <pre>{JSON.stringify(schedule, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/scenarios/index.ts
+++ b/apps/frontend/src/features/scenarios/index.ts
@@ -1,0 +1,1 @@
+export { default as ScenarioPlanner } from "./ScenarioPlanner";


### PR DESCRIPTION
## Summary
- add migration for loan_scenarios linked to clients
- implement amortization and buydown loan calculators
- build front-end scenario planner component

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b893d479748321bba893afe9c17ce3