### PR TITLE
feat: add pipeline tables and integration clients

### DIFF
--- a/apps/backend/db/schema.sql
+++ b/apps/backend/db/schema.sql
@@ -1,0 +1,14 @@
+CREATE TABLE applications (
+    id SERIAL PRIMARY KEY,
+    applicant_name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE pipeline_stages (
+    id SERIAL PRIMARY KEY,
+    application_id INTEGER REFERENCES applications(id) ON DELETE CASCADE,
+    stage_name TEXT NOT NULL,
+    completed BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/apps/backend/src/integrations/credit.ts
+++ b/apps/backend/src/integrations/credit.ts
@@ -1,0 +1,10 @@
+import fetch from 'node-fetch';
+
+export async function fetchCreditScore(ssn: string) {
+  const url = `${process.env.CREDIT_API_URL}/score?ssn=${encodeURIComponent(ssn)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Credit API error: ${res.status}`);
+  }
+  return res.json();
+}

--- a/apps/backend/src/integrations/income.ts
+++ b/apps/backend/src/integrations/income.ts
@@ -1,0 +1,10 @@
+import fetch from 'node-fetch';
+
+export async function fetchIncomeVerification(ssn: string) {
+  const url = `${process.env.INCOME_API_URL}/verify?ssn=${encodeURIComponent(ssn)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Income API error: ${res.status}`);
+  }
+  return res.json();
+}

--- a/apps/backend/src/integrations/property.ts
+++ b/apps/backend/src/integrations/property.ts
@@ -1,0 +1,10 @@
+import fetch from 'node-fetch';
+
+export async function fetchPropertyDetails(address: string) {
+  const url = `${process.env.PROPERTY_API_URL}/details?address=${encodeURIComponent(address)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Property API error: ${res.status}`);
+  }
+  return res.json();
+}

--- a/apps/backend/src/resolvers/pipeline.ts
+++ b/apps/backend/src/resolvers/pipeline.ts
@@ -1,0 +1,37 @@
+import { PubSub } from 'graphql-subscriptions';
+import type { Knex } from 'knex';
+
+const pubsub = new PubSub();
+const PIPELINE_UPDATED = 'PIPELINE_UPDATED';
+
+interface Context {
+  db: Knex;
+}
+
+export const pipelineResolvers = {
+  Query: {
+    async pipelineStages(_: unknown, { applicationId }: { applicationId: number }, { db }: Context) {
+      return db('pipeline_stages').where({ application_id: applicationId });
+    },
+  },
+  Mutation: {
+    async advancePipeline(
+      _: unknown,
+      { applicationId, stageName }: { applicationId: number; stageName: string },
+      { db }: Context,
+    ) {
+      const [stage] = await db('pipeline_stages')
+        .insert({ application_id: applicationId, stage_name: stageName })
+        .returning('*');
+      await pubsub.publish(PIPELINE_UPDATED, { pipelineUpdated: stage });
+      return stage;
+    },
+  },
+  Subscription: {
+    pipelineUpdated: {
+      subscribe: () => pubsub.asyncIterator([PIPELINE_UPDATED]),
+    },
+  },
+};
+
+export default pipelineResolvers;


### PR DESCRIPTION
## Summary
- introduce `applications` and `pipeline_stages` tables
- add pipeline resolver with mutation and subscription support
- integrate credit, income, and property API clients

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8825256d88321b5d394d19ed769b2