### PR TITLE
Add dashboard backend resolver and frontend page

### DIFF
--- a/apps/backend/src/db/views.sql
+++ b/apps/backend/src/db/views.sql
@@ -1,0 +1,15 @@
+-- SQL views used for aggregating metrics for the dashboard.
+
+-- View providing key performance indicators.
+CREATE VIEW IF NOT EXISTS kpi_metrics AS
+SELECT
+  COUNT(*) FILTER (WHERE status = 'closed-won')  AS deals_won,
+  COUNT(*) FILTER (WHERE status = 'open')        AS deals_open,
+  COALESCE(SUM(amount), 0)                       AS pipeline_value
+FROM deals;
+
+-- View grouping deals by pipeline stage for the Kanban board.
+CREATE VIEW IF NOT EXISTS pipeline_stage_deals AS
+SELECT stage, json_agg(deals.* ORDER BY updated_at DESC) AS deals
+FROM deals
+GROUP BY stage;

--- a/apps/backend/src/electric.ts
+++ b/apps/backend/src/electric.ts
@@ -1,0 +1,10 @@
+import { connect } from 'electric-sql/node';
+
+// Establish a singleton ElectricSQL connection that can be reused across
+// resolvers. This assumes that the DATABASE_URL environment variable points
+// to the underlying Postgres database.
+export const electric = connect(process.env.DATABASE_URL as string, {
+  migrations: './src/db/views.sql',
+});
+
+export type ElectricClient = Awaited<ReturnType<typeof electric>>;

--- a/apps/backend/src/resolvers/dashboard.ts
+++ b/apps/backend/src/resolvers/dashboard.ts
@@ -1,0 +1,38 @@
+import type { ElectricClient } from '../electric';
+import { electric } from '../electric';
+
+// Types describing KPI information returned by the database view.
+export interface KPI {
+  deals_won: number;
+  deals_open: number;
+  pipeline_value: number;
+}
+
+export const dashboardResolver = {
+  Query: {
+    // Expose aggregated KPI metrics from the dedicated SQL view.
+    kpis: async (): Promise<KPI> => {
+      const db: ElectricClient = await electric;
+      const { rows } = await db.raw('SELECT * FROM kpi_metrics');
+      return rows[0] as KPI;
+    },
+    // Provide the Kanban pipeline grouped by stage.
+    pipeline: async () => {
+      const db: ElectricClient = await electric;
+      const { rows } = await db.raw('SELECT * FROM pipeline_stage_deals');
+      return rows;
+    },
+  },
+  Subscription: {
+    // Live KPI updates leveraging ElectricSQL's liveQuery capability.
+    kpiUpdated: {
+      subscribe: async function* () {
+        const db: ElectricClient = await electric;
+        const iterator = db.liveQuery('SELECT * FROM kpi_metrics');
+        for await (const rows of iterator) {
+          yield { kpiUpdated: rows[0] as KPI };
+        }
+      },
+    },
+  },
+};

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { gql, useQuery, useSubscription } from '@apollo/client';
+
+// GraphQL query fetching KPIs and pipeline data from the backend
+const DASHBOARD_QUERY = gql`
+  query DashboardData {
+    kpis { deals_won deals_open pipeline_value }
+    pipeline { stage deals }
+  }
+`;
+
+// Subscription providing live KPI updates via ElectricSQL
+const KPI_SUBSCRIPTION = gql`
+  subscription OnKPIUpdated {
+    kpiUpdated { deals_won deals_open pipeline_value }
+  }
+`;
+
+export default function Dashboard() {
+  const { data, refetch } = useQuery(DASHBOARD_QUERY);
+  useSubscription(KPI_SUBSCRIPTION, { onData: () => refetch() });
+
+  const kpi = data?.kpis || { deals_won: 0, deals_open: 0, pipeline_value: 0 };
+  const pipeline = data?.pipeline || [];
+
+  return (
+    <div className="dashboard">
+      <section className="widgets">
+        <KPICard label="Deals Won" value={kpi.deals_won} />
+        <KPICard label="Open Deals" value={kpi.deals_open} />
+        <KPICard label="Pipeline Value" value={kpi.pipeline_value} />
+      </section>
+      <PipelineBoard stages={pipeline} />
+    </div>
+  );
+}
+
+interface CardProps { label: string; value: number }
+function KPICard({ label, value }: CardProps) {
+  return (
+    <div className="kpi-card">
+      <div className="kpi-label">{label}</div>
+      <div className="kpi-value">{value}</div>
+    </div>
+  );
+}
+
+interface PipelineStage { stage: string; deals: any[] }
+function PipelineBoard({ stages }: { stages: PipelineStage[] }) {
+  return (
+    <div className="pipeline-board">
+      {stages.map((s) => (
+        <div key={s.stage} className="pipeline-column">
+          <h3>{s.stage}</h3>
+          {s.deals?.map((d: any) => (
+            <div key={d.id} className="deal-card">
+              {d.name}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SQL views and ElectricSQL connection for aggregated metrics
- expose KPI query and subscription resolver
- create React dashboard page with KPI widgets and pipeline kanban board

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b890c56c8083218f8b45c93727f75d