### PR TITLE
feat: add document handling

### DIFF
--- a/apps/backend/src/db/migrations/001_create_documents.sql
+++ b/apps/backend/src/db/migrations/001_create_documents.sql
@@ -1,0 +1,6 @@
+CREATE TABLE documents (
+    key TEXT PRIMARY KEY,
+    owner TEXT NOT NULL,
+    checksum TEXT NOT NULL,
+    status TEXT NOT NULL
+);

--- a/apps/backend/src/resolvers/documents.ts
+++ b/apps/backend/src/resolvers/documents.ts
@@ -1,0 +1,46 @@
+export interface Document {
+  key: string;
+  owner: string;
+  checksum: string;
+  status: string;
+  templateId?: string;
+  isCompliant?: boolean;
+}
+
+// In-memory document store for example purposes
+const documents: Record<string, Document> = {};
+
+export const DocumentResolver = {
+  Query: {
+    documents: (): Document[] => Object.values(documents),
+    document: (_: unknown, { key }: { key: string }): Document | null => documents[key] || null,
+  },
+  Mutation: {
+    uploadDocument: (
+      _: unknown,
+      { key, owner, checksum, status }: Document
+    ): Document => {
+      const doc: Document = { key, owner, checksum, status };
+      documents[key] = doc;
+      return doc;
+    },
+    assignTemplate: (
+      _: unknown,
+      { key, templateId }: { key: string; templateId: string }
+    ): Document | null => {
+      const doc = documents[key];
+      if (!doc) return null;
+      doc.templateId = templateId;
+      return doc;
+    },
+    markCompliance: (
+      _: unknown,
+      { key, isCompliant }: { key: string; isCompliant: boolean }
+    ): Document | null => {
+      const doc = documents[key];
+      if (!doc) return null;
+      doc.isCompliant = isCompliant;
+      return doc;
+    },
+  },
+};

--- a/apps/frontend/src/features/documents/Preview.tsx
+++ b/apps/frontend/src/features/documents/Preview.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface PreviewProps {
+  key: string;
+  owner: string;
+  checksum: string;
+  status: string;
+  templateId?: string;
+  isCompliant?: boolean;
+}
+
+export const Preview: React.FC<PreviewProps> = (props) => {
+  const { key, owner, checksum, status, templateId, isCompliant } = props;
+
+  return (
+    <div>
+      <h3>Document Preview</h3>
+      <ul>
+        <li>Key: {key}</li>
+        <li>Owner: {owner}</li>
+        <li>Checksum: {checksum}</li>
+        <li>Status: {status}</li>
+        {templateId && <li>Template: {templateId}</li>}
+        {typeof isCompliant === "boolean" && (
+          <li>Compliance: {isCompliant ? "Compliant" : "Not compliant"}</li>
+        )}
+      </ul>
+    </div>
+  );
+};

--- a/apps/frontend/src/features/documents/Requirement.tsx
+++ b/apps/frontend/src/features/documents/Requirement.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface RequirementProps {
+  isRequired: boolean;
+  isCompliant?: boolean;
+}
+
+export const Requirement: React.FC<RequirementProps> = ({ isRequired, isCompliant }) => {
+  if (!isRequired) {
+    return <p>No document required.</p>;
+  }
+  return (
+    <p>
+      Document is required and{typeof isCompliant === "boolean" ? (isCompliant ? " compliant." : " not compliant.") : " pending review."}
+    </p>
+  );
+};

--- a/apps/frontend/src/features/documents/Upload.tsx
+++ b/apps/frontend/src/features/documents/Upload.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from "react";
+
+export const Upload: React.FC = () => {
+  const [file, setFile] = useState<File | null>(null);
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    // Placeholder for upload implementation
+    console.log("Uploading", file.name);
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+      <button type="submit" disabled={!file}>
+        Upload
+      </button>
+    </form>
+  );
+};


### PR DESCRIPTION
## Summary
- add documents table
- add resolver with template assignment and compliance flags
- add document upload, preview and requirement UIs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b890caa5f883218bc0f94a2753a889