### PR TITLE
Add database auth tables and role-based guards

### DIFF
--- a/apps/backend/db/init.sql
+++ b/apps/backend/db/init.sql
@@ -1,0 +1,22 @@
+-- Initialization script for PostgreSQL users and sessions tables
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'user',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+-- Index to quickly find valid sessions
+CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,0 +1,30 @@
+import express, { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+const JWT_SECRET = process.env.JWT_SECRET || 'development-secret';
+
+export interface AuthenticatedRequest extends Request {
+  user?: { id: string; role: string };
+}
+
+// JWT verification middleware
+export function verifyJWT(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+  const auth = req.headers['authorization'];
+  if (!auth) {
+    return res.status(401).json({ error: 'Authorization header missing' });
+  }
+
+  const token = auth.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { sub: string; role: string };
+    req.user = { id: payload.sub, role: payload.role };
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+app.use(verifyJWT);
+
+export default app;

--- a/apps/backend/src/resolvers/clients.ts
+++ b/apps/backend/src/resolvers/clients.ts
@@ -1,0 +1,13 @@
+import { AuthenticatedRequest } from '../index';
+
+interface Context {
+  req: AuthenticatedRequest;
+}
+
+export function listClients(_parent: unknown, _args: unknown, context: Context) {
+  if (context.req.user?.role !== 'admin') {
+    throw new Error('Forbidden');
+  }
+  // Placeholder: return empty list of clients
+  return [];
+}

--- a/apps/backend/src/resolvers/documents.ts
+++ b/apps/backend/src/resolvers/documents.ts
@@ -1,0 +1,14 @@
+import { AuthenticatedRequest } from '../index';
+
+interface Context {
+  req: AuthenticatedRequest;
+}
+
+export function listDocuments(_parent: unknown, _args: unknown, context: Context) {
+  const role = context.req.user?.role;
+  if (role !== 'admin' && role !== 'user') {
+    throw new Error('Forbidden');
+  }
+  // Placeholder: return empty list of documents
+  return [];
+}


### PR DESCRIPTION
## Summary
- add users and sessions tables with hashed passwords
- implement JWT verification middleware
- restrict clients and documents resolvers based on user roles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b893d005f88321bbbfa929f948b129