### PR TITLE
feat(clients): add client detail view with search and SSN controls

### DIFF
--- a/apps/frontend/src/features/clients/ClientDetail.tsx
+++ b/apps/frontend/src/features/clients/ClientDetail.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Client } from './ClientList';
+import { formatSSN } from './ssn';
+
+interface Props {
+  client: Client;
+  authorized?: boolean;
+  onClose: () => void;
+}
+
+const ClientDetail: React.FC<Props> = ({ client, authorized = false, onClose }) => {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginTop: '1rem' }}>
+      <h3>Client Detail</h3>
+      <p><strong>Name:</strong> {client.name}</p>
+      <p><strong>Status:</strong> {client.status}</p>
+      <p><strong>SSN:</strong> {formatSSN(client.ssn, authorized)}</p>
+      <button onClick={onClose}>Close</button>
+    </div>
+  );
+};
+
+export default ClientDetail;

--- a/apps/frontend/src/features/clients/ClientList.tsx
+++ b/apps/frontend/src/features/clients/ClientList.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import ClientDetail from './ClientDetail';
+import { formatSSN } from './ssn';
+
+export interface Client {
+  id: number;
+  name: string;
+  ssn: string;
+  status: 'active' | 'inactive';
+}
+
+// Mock data for demonstration purposes
+const clients: Client[] = [
+  { id: 1, name: 'Alice Smith', ssn: '123-45-6789', status: 'active' },
+  { id: 2, name: 'Bob Johnson', ssn: '987-65-4321', status: 'inactive' },
+  { id: 3, name: 'Charlie Brown', ssn: '111-22-3333', status: 'active' },
+];
+
+interface Props {
+  authorized?: boolean;
+}
+
+const ClientList: React.FC<Props> = ({ authorized = false }) => {
+  const [selected, setSelected] = useState<Client | null>(null);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('all');
+
+  const filtered = clients.filter((client) => {
+    const matchesSearch = client.name.toLowerCase().includes(search.toLowerCase());
+    const matchesStatus = statusFilter === 'all' || client.status === statusFilter;
+    return matchesSearch && matchesStatus;
+  });
+
+  return (
+    <div>
+      <h2>Clients</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Search by name"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as any)}
+          style={{ marginLeft: '0.5rem' }}
+        >
+          <option value="all">All</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </select>
+      </div>
+      <ul>
+        {filtered.map((client) => (
+          <li key={client.id}>
+            <button onClick={() => setSelected(client)}>{client.name}</button>
+            {' '}
+            <small>{formatSSN(client.ssn, authorized)}</small>
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <ClientDetail client={selected} authorized={authorized} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  );
+};
+
+export default ClientList;

--- a/apps/frontend/src/features/clients/ssn.ts
+++ b/apps/frontend/src/features/clients/ssn.ts
@@ -1,0 +1,26 @@
+/**
+ * Utility helpers for handling Social Security Numbers.
+ */
+
+/**
+ * Naive "decryption" placeholder. In a real application this would use a
+ * strong cryptographic routine and the encrypted value would be stored on the
+ * server. For demonstration we simply return the given value.
+ */
+export function decryptSSN(encrypted: string): string {
+  // Placeholder: the value is assumed to already be decrypted
+  return encrypted;
+}
+
+/**
+ * Returns a masked version of the SSN unless the caller is authorized. If the
+ * caller is authorized, the SSN is "decrypted" and returned in full.
+ */
+export function formatSSN(encrypted: string, authorized: boolean): string {
+  const ssn = authorized ? decryptSSN(encrypted) : encrypted;
+  if (authorized) {
+    return ssn;
+  }
+  // Mask all digits except the last four
+  return ssn.replace(/\d(?=\d{4})/g, '*');
+}


### PR DESCRIPTION
## Summary
- add client list with search and status filters
- show client details and mask or decrypt SSNs based on authorization
- provide SSN utilities to centralize masking/decryption logic

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b893d23e388321b957aa25b47e98dc